### PR TITLE
Render template in sandboxed environment

### DIFF
--- a/inkpy_jinja/backends/libre.py
+++ b/inkpy_jinja/backends/libre.py
@@ -23,7 +23,7 @@ except:
         'unotools package must be installed.'
         ' Run pip install inkpy_jinja[libre]'
     )
-from inkpy_jinja.backends.base import PDFBackend
+from inkpy_jinja.backends.base import PDFBackend  # noqa
 
 
 class LibreOfficeContext(object):

--- a/inkpy_jinja/converter.py
+++ b/inkpy_jinja/converter.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import zipfile
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from inkpy_jinja.backends.external_script import ExternalRenderer
 
@@ -111,7 +111,8 @@ class Converter(object):
         _render(styles_xml)
 
     def _jinja_renderer(self, file_content):
-        template = Template(file_content.decode('utf-8'))
+        jinja_env = SandboxedEnvironment()
+        template = jinja_env.from_string(file_content.decode('utf-8'))
         rendered = template.render(**self.data)
         return rendered
 

--- a/inkpy_jinja/tests/samples/sample.txt
+++ b/inkpy_jinja/tests/samples/sample.txt
@@ -1,0 +1,1 @@
+Lorem ipsum {{ test }}

--- a/inkpy_jinja/tests/samples/sample_not_safe.txt
+++ b/inkpy_jinja/tests/samples/sample_not_safe.txt
@@ -1,0 +1,1 @@
+Lorem ipsum {{ ''.__class__.__name__ }}

--- a/inkpy_jinja/tests/tests.py
+++ b/inkpy_jinja/tests/tests.py
@@ -1,28 +1,33 @@
 # -*- coding: utf-8 -*-
+import os
 import unittest
 
-from inkpy_jinja.converter import Converter, FileDoesNotExist
+from jinja2.exceptions import SecurityError
+
+from inkpy_jinja.converter import Converter
+from inkpy_jinja.backends.libre import LibreOfficePDFBackend
+
+SAMPLES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'samples'))
+SAMPLE_TXT = os.path.join(SAMPLES_DIR, 'sample.txt')
+SAMPLE_NOT_SAFE_TXT = os.path.join(SAMPLES_DIR, 'sample_not_safe.txt')
 
 
 class ConverterTests(unittest.TestCase):
+    def _get_converter(self, data, file=SAMPLE_TXT):
+        return Converter(
+            SAMPLE_TXT, '', data,
+            backend=LibreOfficePDFBackend
+        )
 
-    def test_given_non_exist_template_should_raise_exception(self):
-        with self.assertRaises(FileDoesNotExist):
+    def test_jinja_renderer(self):
+        c = self._get_converter(data={'id': 123, 'test': '1234'})
+        result = c._jinja_renderer(open(SAMPLE_TXT, 'rb').read())
+        self.assertEqual(result, 'Lorem ipsum 1234')
 
-        # OK = 'Maj 31, 2014'
-        # source_file = output_path = 'unused_in_test'
-        # test_data = {
-        #     'id': 'mocked-id',
-        #     'today': datetime.date(2014, 5, 31),
-        # }
-        # converter = MockedConverter(source_file, output_path, test_data)
-        # file_content = "{{today}}"
-
-        # rendered = converter._django_renderer(file_content)
-        # self.assertNotIn('Maj', rendered)
-        # converter.lang_code = 'pl'
-        # rendered = converter._django_renderer(file_content)
-        # self.assertEqual(rendered, OK)
+    def test_jinja_renderer_not_safe(self):
+        c = self._get_converter(data={'id': 123})
+        with self.assertRaises(SecurityError):
+            c._jinja_renderer(open(SAMPLE_NOT_SAFE_TXT, 'rb').read())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now jinja templates are rendered in sandboxed environment to secure evaluate untrusted templates. Access to unsafe attributes and methods is denied. See http://jinja.pocoo.org/docs/dev/sandbox/ for details.
